### PR TITLE
navigation drawer에서 메일 타입 별 프래그먼트 이동 구현

### DIFF
--- a/app/src/main/java/com/nimok97/mailproject/ui/MainActivity.kt
+++ b/app/src/main/java/com/nimok97/mailproject/ui/MainActivity.kt
@@ -79,10 +79,19 @@ class MainActivity : AppCompatActivity() {
     }
 
     override fun onBackPressed() {
-        if (binding.bottomNavigationViewMain.selectedItemId == R.id.fragment_search) {
+        if (binding.bottomNavigationViewMain.selectedItemId == R.id.fragment_search) { // 현재 탭이 Setting
             binding.bottomNavigationViewMain.selectedItemId = R.id.fragment_mail
-        } else {
-            super.onBackPressed()
+        } else { // 현재 탭이 Mail
+            mailFragment?.let{
+                PrintLog.printLog("${it.childFragmentManager.backStackEntryCount}")
+
+                if(it.childFragmentManager.backStackEntryCount >= 1){
+                    it.backToPrimary()
+                }
+                else{
+                    super.onBackPressed()
+                }
+            }
         }
 
         // super.onBackPressed()

--- a/app/src/main/java/com/nimok97/mailproject/ui/mail/MailFragment.kt
+++ b/app/src/main/java/com/nimok97/mailproject/ui/mail/MailFragment.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.activityViewModels
 import com.nimok97.mailproject.R
 import com.nimok97.mailproject.common.BottomNavigaionFragment
@@ -13,11 +14,21 @@ import com.nimok97.mailproject.common.PrintLog
 import com.nimok97.mailproject.common.SaveBottomNavigationTab
 import com.nimok97.mailproject.databinding.FragmentMailBinding
 import com.nimok97.mailproject.ui.MainViewModel
+import com.nimok97.mailproject.ui.mail.type.PrimaryFragment
+import com.nimok97.mailproject.ui.mail.type.PromotionsFragment
+import com.nimok97.mailproject.ui.mail.type.SocialFragment
+import com.nimok97.mailproject.ui.mail.type.TestFragment
+import com.nimok97.mailproject.ui.setting.SettingFragment
 
 class MailFragment : Fragment(), SaveBottomNavigationTab {
 
     private lateinit var binding : FragmentMailBinding
     private val viewModel : MainViewModel by activityViewModels()
+
+    private val primaryFragment by lazy { PrimaryFragment() }
+    private val socialFragment by lazy { SocialFragment() }
+    private val promotionsFragment by lazy { PromotionsFragment() }
+    private val testFragment by lazy { TestFragment() }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -37,6 +48,7 @@ class MailFragment : Fragment(), SaveBottomNavigationTab {
 
         setAppBar()
         setNavView()
+        changeFragment(primaryFragment)
     }
 
     override fun updateCurrentTab() {
@@ -54,8 +66,50 @@ class MailFragment : Fragment(), SaveBottomNavigationTab {
 
         binding.navViewMail.setNavigationItemSelectedListener{ menuItem ->
             menuItem.isChecked = true
+            when(menuItem.itemId){
+                R.id.fragment_primary -> {
+                    clearBackStack()
+                    changeFragment(primaryFragment)
+                }
+                R.id.fragment_social -> {
+                    childFragmentManager.popBackStackImmediate("Social", FragmentManager.POP_BACK_STACK_INCLUSIVE)
+                    childFragmentManager.beginTransaction()
+                        .replace(R.id.fragmentContainerView_mail, socialFragment, "Social")
+                        .addToBackStack("Social")
+                        .commit()
+                }
+                R.id.fragment_promotions -> {
+                    childFragmentManager.popBackStackImmediate("Promotions", FragmentManager.POP_BACK_STACK_INCLUSIVE)
+                    childFragmentManager.beginTransaction()
+                        .replace(R.id.fragmentContainerView_mail, promotionsFragment, "Promotions")
+                        .addToBackStack("Promotions")
+                        .commit()
+                }
+                R.id.fragment_test -> {
+                    childFragmentManager.popBackStackImmediate("Test", FragmentManager.POP_BACK_STACK_INCLUSIVE)
+                    childFragmentManager.beginTransaction()
+                        .replace(R.id.fragmentContainerView_mail, testFragment, "Test")
+                        .addToBackStack("Test")
+                        .commit()
+                }
+            }
             binding.drawerLayout.close()
             true
         }
+    }
+
+    fun backToPrimary(){
+        clearBackStack()
+        changeFragment(primaryFragment)
+        binding.navViewMail.menu.findItem(R.id.fragment_primary).isChecked = true
+    }
+
+    private fun changeFragment(fragment: Fragment) {
+        childFragmentManager.beginTransaction().replace(R.id.fragmentContainerView_mail, fragment)
+            .commit()
+    }
+
+    private fun clearBackStack() {
+        childFragmentManager.popBackStack(null, FragmentManager.POP_BACK_STACK_INCLUSIVE)
     }
 }

--- a/app/src/main/java/com/nimok97/mailproject/ui/mail/type/PromotionsFragment.kt
+++ b/app/src/main/java/com/nimok97/mailproject/ui/mail/type/PromotionsFragment.kt
@@ -32,4 +32,14 @@ class PromotionsFragment : Fragment() {
 
 
     }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        PrintLog.printLog("$this / onDestroyView")
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        PrintLog.printLog("$this / onDestroy")
+    }
 }

--- a/app/src/main/java/com/nimok97/mailproject/ui/mail/type/SocialFragment.kt
+++ b/app/src/main/java/com/nimok97/mailproject/ui/mail/type/SocialFragment.kt
@@ -31,4 +31,14 @@ class SocialFragment : Fragment() {
 
 
     }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        PrintLog.printLog("$this / onDestroyView")
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        PrintLog.printLog("$this / onDestroy")
+    }
 }

--- a/app/src/main/java/com/nimok97/mailproject/ui/mail/type/TestFragment.kt
+++ b/app/src/main/java/com/nimok97/mailproject/ui/mail/type/TestFragment.kt
@@ -8,11 +8,12 @@ import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import com.nimok97.mailproject.R
 import com.nimok97.mailproject.common.PrintLog
-import com.nimok97.mailproject.databinding.FragmentPrimaryBinding
+import com.nimok97.mailproject.databinding.FragmentPromotionsBinding
+import com.nimok97.mailproject.databinding.FragmentTestBinding
 
-class PrimaryFragment : Fragment() {
+class TestFragment: Fragment() {
 
-    private lateinit var binding: FragmentPrimaryBinding
+    private lateinit var binding: FragmentTestBinding
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -20,7 +21,7 @@ class PrimaryFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         PrintLog.printLog("$this / onCreateView")
-        binding = DataBindingUtil.inflate(inflater, R.layout.fragment_primary, container, false)
+        binding = DataBindingUtil.inflate(inflater, R.layout.fragment_test, container, false)
         return binding.root
     }
 

--- a/app/src/main/res/layout/fragment_test.xml
+++ b/app/src/main/res/layout/fragment_test.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            android:text="test"/>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/menu/navigationview_mail_menu.xml
+++ b/app/src/main/res/menu/navigationview_mail_menu.xml
@@ -16,5 +16,9 @@
             android:id="@+id/fragment_promotions"
             android:icon="@drawable/ic_promotions"
             android:title="@string/mail_drawer_promotions" />
+        <item
+            android:id="@+id/fragment_test"
+            android:icon="@drawable/ic_launcher_foreground"
+            android:title="Test" />
     </group>
 </menu>


### PR DESCRIPTION
- Primary를 제외한 다른 메일 타입의 프래그먼트에서 뒤로가기 버튼 누르면 Primary 프래그먼트로 복귀
- Primary 프래그먼트에서 뒤로가기 버튼 누를 시 앱 종료
- Primary로 이동 시에는 프래그먼트 백스택 초기화